### PR TITLE
Use "regex" as a prefix for the field tags to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ This package allows you to express regular expressions by defining a struct, and
 import "github.com/alexflint/go-restructure"
 
 type EmailAddress struct {
-	_    string `^`
-	User string `\w+`
-	_    string `@`
-	Host string `[^@]+`
-	_    string `$`
+	_    string `regex:"^"`
+	User string `regex:"\\w+"`
+	_    string `regex:"@"`
+	Host string `regex:"[^@]+"`
+	_    string `regex:"$"`
 }
 
 func main() {
@@ -41,17 +41,17 @@ Here is a slightly more sophisticated email address parser that uses nested stru
 import "github.com/alexflint/go-restructure"
 
 type Hostname struct {
-	Domain string   `\w+`
-	_      struct{} `\.`
-	TLD    string   `\w+`
+	Domain string   `regex:"\\w+"`
+	_      struct{} `regex:"\\."`
+	TLD    string   `regex:"\\w+"`
 }
 
 type EmailAddress struct {
-	_    struct{} `^`
-	User string   `[a-zA-Z0-9._%+-]+`
-	_    struct{} `@`
+	_    struct{} `regex:"^"`
+	User string   `regex:"[a-zA-Z0-9._%+-]+"`
+	_    struct{} `regex:"@"`
 	Host *Hostname
-	_    struct{} `$`
+	_    struct{} `regex:"$"`
 }
 
 func main() {

--- a/builder.go
+++ b/builder.go
@@ -42,7 +42,7 @@ func (b *builder) nextCaptureIndex() int {
 }
 
 func (b *builder) terminal(f reflect.StructField, fullName string) (*Field, *syntax.Regexp, error) {
-	pattern := string(f.Tag)
+	pattern := f.Tag.Get("regex")
 	if pattern == "" {
 		return nil, nil, nil
 	}
@@ -72,7 +72,7 @@ func (b *builder) terminal(f reflect.StructField, fullName string) (*Field, *syn
 }
 
 func (b *builder) nonterminal(f reflect.StructField, fullName string) (*Field, *syntax.Regexp, error) {
-	opstr := f.Tag
+	opstr := f.Tag.Get("regex")
 	child, expr, err := b.structure(f.Type)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
This PR fixes issue #2 by prefixing the field tags with "regex". An additional test with the URL struct shows how this would play nicely with the json tags.