### PR TITLE
deal with subcaptures in terminal expressions

### DIFF
--- a/restructure_test.go
+++ b/restructure_test.go
@@ -96,3 +96,16 @@ func TestMatchPtrURLFailed(t *testing.T) {
 	assert.Nil(t, v.Scheme)
 	assert.Nil(t, v.Host)
 }
+
+type HasSubcaptures struct {
+	Name string `a(bc)?d`
+}
+
+func TestRemoveSubcaptures(t *testing.T) {
+	pattern, err := Compile(HasSubcaptures{}, Options{})
+	require.NoError(t, err)
+
+	var v HasSubcaptures
+	require.True(t, pattern.Find(&v, "abcd"))
+	assert.Equal(t, "abcd", v.Name)
+}

--- a/transform.go
+++ b/transform.go
@@ -1,0 +1,24 @@
+package restructure
+
+import "regexp/syntax"
+
+type transformer func(expr *syntax.Regexp) ([]*syntax.Regexp, error)
+
+// transform replaces each node in a regex AST with the return value of the given function
+// it processes the children of a node before the node itself
+func transform(expr *syntax.Regexp, f transformer) (*syntax.Regexp, error) {
+	var newchildren []*syntax.Regexp
+	for _, child := range expr.Sub {
+		newchild, err := transform(child, f)
+		if err != nil {
+			return nil, err
+		}
+		replacements, err := f(newchild)
+		if err != nil {
+			return nil, err
+		}
+		newchildren = append(newchildren, replacements...)
+	}
+	expr.Sub = newchildren
+	return expr, nil
+}


### PR DESCRIPTION
This PR changes builder to traverse the AST generated by terminal expressions and remove subcaptures. The following now works as expected:

```go

type HasSubcaptures struct {
		 Name string `a(bc)?d`
}

func TestRemoveSubcaptures(t *testing.T) {
		 pattern, err := Compile(HasSubcaptures{}, Options{})
		 require.NoError(t, err)

		 var v HasSubcaptures
		 require.True(t, pattern.Find(&v, "abcd"))
		 assert.Equal(t, "abcd", v.Name)
}
```