### PR TITLE
Add optional regexp: tag key

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ func main() {
 	fmt.Println(addr.Host) // prints "example.com"
 }
 ```
+(Note that the above is far too simplistic to be used as a serious email address validator.)
 
 The regular expression that was executed was the concatenation of the struct tags:
 
@@ -47,6 +48,8 @@ type EmailAddress struct {
 	_    string `regexp:"$"`
 }
 ```
+
+### Nested Structs
 
 Here is a slightly more sophisticated email address parser that uses nested structs:
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ This package allows you to express regular expressions by defining a struct, and
 import "github.com/alexflint/go-restructure"
 
 type EmailAddress struct {
-	_    string `regexp:"^"`
-	User string `regexp:"\\w+"`
-	_    string `regexp:"@"`
-	Host string `regexp:"[^@]+"`
-	_    string `regexp:"$"`
+	_    string `^`
+	User string `\w+`
+	_    string `@`
+	Host string `[^@]+`
+	_    string `$`
 }
 
 func main() {
@@ -27,7 +27,6 @@ func main() {
 	fmt.Println(addr.Host) // prints "example.com"
 }
 ```
-(Note that the above is far too simplistic to be used as a serious email address validator.)
 
 The regular expression that was executed was the concatenation of the struct tags:
 
@@ -37,23 +36,35 @@ The regular expression that was executed was the concatenation of the struct tag
 
 The first submatch was inserted into the `User` field and the second into the `Host` field.
 
+You may also use the `regexp:` tag key, but keep in mind that you must escape quotes and backslashes:
+
+```go
+type EmailAddress struct {
+	_    string `regexp:"^"`
+	User string `regexp:"\\w+"`
+	_    string `regexp:"@"`
+	Host string `regexp:"[^@]+"`
+	_    string `regexp:"$"`
+}
+```
+
 Here is a slightly more sophisticated email address parser that uses nested structs:
 
 ```go
 import "github.com/alexflint/go-restructure"
 
 type Hostname struct {
-	Domain string   `regexp:"\\w+"`
-	_      struct{} `regexp:"\\."`
-	TLD    string   `regexp:"\\w+"`
+	Domain string   `\w+`
+	_      struct{} `\.`
+	TLD    string   `\w+`
 }
 
 type EmailAddress struct {
-	_    struct{} `regexp:"^"`
-	User string   `regexp:"[a-zA-Z0-9._%+-]+"`
-	_    struct{} `regexp:"@"`
+	_    struct{} `^`
+	User string   `[a-zA-Z0-9._%+-]+`
+	_    struct{} `@`
 	Host *Hostname
-	_    struct{} `regexp:"$"`
+	_    struct{} `$`
 }
 
 func main() {
@@ -67,17 +78,7 @@ func main() {
 }
 ```
 
-If adding backslashes to escape your regular expressions become too tedious then you may omit the `regexp:` tag, but beware that this will make it impossible to add tags for other libraries to the same struct:
-
-```
-type Hostname struct {
-	Domain string   `\\w+`
-	_      struct{} `\\.`
-	TLD    string   `\\w+`
-}
-```
-
-Compare this to using the standard library `FindStringSubmatchIndex` directly:
+Compare this to using the standard library `regexp.FindStringSubmatchIndex` directly:
 
 ```go
 func main() {

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ This package allows you to express regular expressions by defining a struct, and
 import "github.com/alexflint/go-restructure"
 
 type EmailAddress struct {
-	_    string `regex:"^"`
-	User string `regex:"\\w+"`
-	_    string `regex:"@"`
-	Host string `regex:"[^@]+"`
-	_    string `regex:"$"`
+	_    string `regexp:"^"`
+	User string `regexp:"\\w+"`
+	_    string `regexp:"@"`
+	Host string `regexp:"[^@]+"`
+	_    string `regexp:"$"`
 }
 
 func main() {
@@ -43,17 +43,17 @@ Here is a slightly more sophisticated email address parser that uses nested stru
 import "github.com/alexflint/go-restructure"
 
 type Hostname struct {
-	Domain string   `regex:"\\w+"`
-	_      struct{} `regex:"\\."`
-	TLD    string   `regex:"\\w+"`
+	Domain string   `regexp:"\\w+"`
+	_      struct{} `regexp:"\\."`
+	TLD    string   `regexp:"\\w+"`
 }
 
 type EmailAddress struct {
-	_    struct{} `regex:"^"`
-	User string   `regex:"[a-zA-Z0-9._%+-]+"`
-	_    struct{} `regex:"@"`
+	_    struct{} `regexp:"^"`
+	User string   `regexp:"[a-zA-Z0-9._%+-]+"`
+	_    struct{} `regexp:"@"`
 	Host *Hostname
-	_    struct{} `regex:"$"`
+	_    struct{} `regexp:"$"`
 }
 
 func main() {
@@ -64,6 +64,16 @@ func main() {
 		fmt.Println(addr.Host.Domain) // prints "example"
 		fmt.Println(addr.Host.TLD)    // prints "com"
 	}
+}
+```
+
+If adding backslashes to escape your regular expressions become too tedious then you may omit the `regexp:` tag, but beware that this will make it impossible to add tags for other libraries to the same struct:
+
+```
+type Hostname struct {
+	Domain string   `\\w+`
+	_      struct{} `\\.`
+	TLD    string   `\\w+`
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ This package allows you to express regular expressions by defining a struct, and
 import "github.com/alexflint/go-restructure"
 
 type EmailAddress struct {
-	_    struct{} `^`
-	User string   `\w+`
-	_    struct{} `@`
-	Host string   `[^@]+`
-	_    struct{} `$`
+	_    string `^`
+	User string `\w+`
+	_    string `@`
+	Host string `[^@]+`
+	_    string `$`
 }
 
 func main() {

--- a/builder.go
+++ b/builder.go
@@ -1,9 +1,11 @@
 package restructure
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"regexp/syntax"
+	"strings"
 )
 
 // A Struct describes how to inflate a match into a struct
@@ -41,8 +43,22 @@ func (b *builder) nextCaptureIndex() int {
 	return k
 }
 
+func (b *builder) extractTag(tag reflect.StructTag) (string, error) {
+	// Allow tags that look like either `regexp:"\\w+"` or just `\w+`
+	if s := tag.Get("regexp"); s != "" {
+		return s, nil
+	} else if strings.Contains(string(tag), `regexp:"`) {
+		return "", errors.New("incorrectly escaped struct tag")
+	} else {
+		return string(tag), nil
+	}
+}
+
 func (b *builder) terminal(f reflect.StructField, fullName string) (*Field, *syntax.Regexp, error) {
-	pattern := f.Tag.Get("regex")
+	pattern, err := b.extractTag(f.Tag)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%s: %v", fullName, err)
+	}
 	if pattern == "" {
 		return nil, nil, nil
 	}
@@ -72,7 +88,10 @@ func (b *builder) terminal(f reflect.StructField, fullName string) (*Field, *syn
 }
 
 func (b *builder) nonterminal(f reflect.StructField, fullName string) (*Field, *syntax.Regexp, error) {
-	opstr := f.Tag.Get("regex")
+	opstr, err := b.extractTag(f.Tag)
+	if err != nil {
+		return nil, nil, err
+	}
 	child, expr, err := b.structure(f.Type)
 	if err != nil {
 		return nil, nil, err
@@ -132,8 +151,10 @@ func (b *builder) structure(t reflect.Type) (*Struct, *syntax.Regexp, error) {
 		if err != nil {
 			return nil, nil, err
 		}
-		exprs = append(exprs, expr)
-		fields = append(fields, field)
+		if field != nil {
+			exprs = append(exprs, expr)
+			fields = append(fields, field)
+		}
 	}
 
 	// Wrap in a concat


### PR DESCRIPTION
This pr makes it possible to use either "naked" struct tags or use the `regexp:` key with escaped regexes.