### PR TITLE
Add position captures

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -143,8 +143,10 @@ func (b *builder) nonterminal(f reflect.StructField, fullName string) (*Field, *
 func (b *builder) field(f reflect.StructField, fullName string) (*Field, *syntax.Regexp, error) {
 	if isScalar(f.Type) {
 		return b.terminal(f, fullName)
+	} else if isStruct(f.Type) {
+		return b.nonterminal(f, fullName)
 	}
-	return b.nonterminal(f, fullName)
+	return nil, nil, nil
 }
 
 func (b *builder) structure(t reflect.Type) (*Struct, *syntax.Regexp, error) {

--- a/builder.go
+++ b/builder.go
@@ -99,6 +99,28 @@ func (b *builder) terminal(f reflect.StructField, fullName string) (*Field, *syn
 	return field, expr, nil
 }
 
+func (b *builder) pos(f reflect.StructField, fullName string) (*Field, *syntax.Regexp, error) {
+	if !isExported(f) {
+		return nil, nil, nil
+	}
+	captureIndex := b.nextCaptureIndex()
+	empty := &syntax.Regexp{
+		Op: syntax.OpEmptyMatch,
+	}
+	expr := &syntax.Regexp{
+		Op:   syntax.OpCapture,
+		Sub:  []*syntax.Regexp{empty},
+		Name: f.Name,
+		Cap:  captureIndex,
+	}
+	field := &Field{
+		index:   f.Index,
+		capture: captureIndex,
+	}
+
+	return field, expr, nil
+}
+
 func (b *builder) nonterminal(f reflect.StructField, fullName string) (*Field, *syntax.Regexp, error) {
 	opstr, err := b.extractTag(f.Tag)
 	if err != nil {
@@ -145,6 +167,8 @@ func (b *builder) field(f reflect.StructField, fullName string) (*Field, *syntax
 		return b.terminal(f, fullName)
 	} else if isStruct(f.Type) {
 		return b.nonterminal(f, fullName)
+	} else if f.Type == posType {
+		return b.pos(f, fullName)
 	}
 	return nil, nil, nil
 }

--- a/inflate.go
+++ b/inflate.go
@@ -11,12 +11,12 @@ var (
 	emptyType     = reflect.TypeOf(struct{}{})
 	stringType    = reflect.TypeOf("")
 	byteArrayType = reflect.TypeOf([]byte{})
-	regionType    = reflect.TypeOf(Region{})
+	submatchType  = reflect.TypeOf(Submatch{})
 	scalarTypes   = []reflect.Type{
 		emptyType,
 		stringType,
 		byteArrayType,
-		regionType,
+		submatchType,
 	}
 )
 
@@ -83,11 +83,11 @@ func inflateScalar(dest reflect.Value, match *match, captureIndex int) error {
 	case emptyType:
 		// ignore the value
 		return nil
-	case regionType:
-		region := dest.Addr().Interface().(*Region)
-		region.Begin = Pos(subcapture.begin)
-		region.End = Pos(subcapture.end)
-		region.Bytes = buf
+	case submatchType:
+		submatch := dest.Addr().Interface().(*Submatch)
+		submatch.Begin = Pos(subcapture.begin)
+		submatch.End = Pos(subcapture.end)
+		submatch.Bytes = buf
 		return nil
 	}
 	return fmt.Errorf("unable to capture into %s", dest.Type().String())

--- a/restructure.go
+++ b/restructure.go
@@ -23,17 +23,17 @@ type Options struct {
 	SyntaxFlags syntax.Flags
 }
 
-type region struct {
+type subcapture struct {
 	begin, end int
 }
 
-func (r region) wasMatched() bool {
+func (r subcapture) wasMatched() bool {
 	return r.begin != -1 && r.end != -1
 }
 
 type match struct {
 	input    []byte
-	captures []region
+	captures []subcapture
 }
 
 func matchFromIndices(indices []int, input []byte) *match {
@@ -41,9 +41,35 @@ func matchFromIndices(indices []int, input []byte) *match {
 		input: input,
 	}
 	for i := 0; i < len(indices); i += 2 {
-		match.captures = append(match.captures, region{indices[i], indices[i+1]})
+		match.captures = append(match.captures, subcapture{indices[i], indices[i+1]})
 	}
 	return match
+}
+
+// BeginPos represents the beginning of a matched region. If a matched struct contains
+// a field of type BeginPos then it will be assigned the begin position of the region
+// matched to that struct.
+type BeginPos int
+
+// EndPos represents the beginning of a matched region. If a matched struct contains
+// a field of type BeginPos then it will be assigned the begin position of the region
+// matched to that struct.
+type EndPos int
+
+// Region represents a matched region. It is a used to determine the begin and and
+// position of the match corresponding to a field. This library treats fields of type
+// `Region` just like `string` or `[]byte` fields, except that the matched string
+// is inserted into `Region.Str` and its begin and end position are inserted into
+// `Region.Begin` and `Region.End`.
+type Region struct {
+	Begin int
+	End   int
+	Bytes []byte
+}
+
+// String gets the matched substring
+func (r *Region) String() string {
+	return string(r.Bytes)
 }
 
 // Regexp is a regular expression that captures submatches into struct fields.
@@ -53,10 +79,6 @@ type Regexp struct {
 	t    reflect.Type
 	opts Options
 }
-
-// Find attempts to match the regular expression against the input string. It
-// returns true if there was a match, and also populates the fields of the provided
-// struct with the contents of each submatch.
 
 // Find attempts to match the regular expression against the input string. It
 // returns true if there was a match, and also populates the fields of the provided

--- a/restructure.go
+++ b/restructure.go
@@ -46,15 +46,10 @@ func matchFromIndices(indices []int, input []byte) *match {
 	return match
 }
 
-// BeginPos represents the beginning of a matched region. If a matched struct contains
-// a field of type BeginPos then it will be assigned the begin position of the region
-// matched to that struct.
-type BeginPos int
-
-// EndPos represents the beginning of a matched region. If a matched struct contains
-// a field of type BeginPos then it will be assigned the begin position of the region
-// matched to that struct.
-type EndPos int
+// Pos represents a position within a matched region. If a matched struct contains
+// a field of type Pos then this field will be assigned a value indicating a position
+// in the input string, where the position corresponds to the index of the Pos field.
+type Pos int
 
 // Region represents a matched region. It is a used to determine the begin and and
 // position of the match corresponding to a field. This library treats fields of type
@@ -62,8 +57,8 @@ type EndPos int
 // is inserted into `Region.Str` and its begin and end position are inserted into
 // `Region.Begin` and `Region.End`.
 type Region struct {
-	Begin int
-	End   int
+	Begin Pos
+	End   Pos
 	Bytes []byte
 }
 

--- a/restructure.go
+++ b/restructure.go
@@ -51,19 +51,19 @@ func matchFromIndices(indices []int, input []byte) *match {
 // in the input string, where the position corresponds to the index of the Pos field.
 type Pos int
 
-// Region represents a matched region. It is a used to determine the begin and and
+// Submatch represents a matched region. It is a used to determine the begin and and
 // position of the match corresponding to a field. This library treats fields of type
-// `Region` just like `string` or `[]byte` fields, except that the matched string
-// is inserted into `Region.Str` and its begin and end position are inserted into
-// `Region.Begin` and `Region.End`.
-type Region struct {
+// `Submatch` just like `string` or `[]byte` fields, except that the matched string
+// is inserted into `Submatch.Str` and its begin and end position are inserted into
+// `Submatch.Begin` and `Submatch.End`.
+type Submatch struct {
 	Begin Pos
 	End   Pos
 	Bytes []byte
 }
 
 // String gets the matched substring
-func (r *Region) String() string {
+func (r *Submatch) String() string {
 	return string(r.Bytes)
 }
 

--- a/restructure_test.go
+++ b/restructure_test.go
@@ -225,3 +225,34 @@ func TestMatchNameDotNamePos(t *testing.T) {
 	assert.EqualValues(t, 7, v.Tail.End)
 	assert.EqualValues(t, 7, v.End)
 }
+
+type DegeneratePos struct {
+	X Pos
+	Y Pos
+}
+
+func TestDegeneratePos(t *testing.T) {
+	// This tests what happens if there are degenerate position captures
+	pattern, err := Compile(DegeneratePos{}, Options{})
+	require.NoError(t, err)
+	var v DegeneratePos
+	assert.True(t, pattern.Find(&v, "abc"))
+	assert.EqualValues(t, 0, v.X)
+	assert.EqualValues(t, 0, v.Y)
+}
+
+type UnexportedPos struct {
+	Exported   Pos
+	unexported Pos
+	_          struct{} `regexp:"$"`
+}
+
+func TestUnexportedPos(t *testing.T) {
+	// This tests what happens if there are non-exported Pos fields
+	pattern, err := Compile(UnexportedPos{}, Options{})
+	require.NoError(t, err)
+	var v UnexportedPos
+	assert.True(t, pattern.Find(&v, "abc"))
+	assert.EqualValues(t, 3, v.Exported)
+	assert.EqualValues(t, 0, v.unexported) // should be ignored
+}

--- a/restructure_test.go
+++ b/restructure_test.go
@@ -164,21 +164,21 @@ func TestRemoveSubcaptures(t *testing.T) {
 }
 
 type DotNameRegion struct {
-	Begin BeginPos
-	End   BeginPos
-
-	Dot  *Region `regexp:"\\."`
-	Name *Region `regexp:"\\w+"`
+	Begin  Pos
+	Dot    *Region `regexp:"\\."`
+	Middle Pos
+	Name   *Region `regexp:"\\w+"`
+	End    Pos
 }
 
 type DotExprRegion struct {
-	Begin BeginPos
-	End   BeginPos
-
-	_    struct{}       `regexp:"^"`
-	Head Region         `regexp:"\\w+"`
-	Tail *DotNameRegion `regexp:"?"`
-	_    struct{}       `regexp:"$"`
+	Begin  Pos
+	_      struct{} `regexp:"^"`
+	Head   Region   `regexp:"\\w+"`
+	Middle Pos
+	Tail   *DotNameRegion `regexp:"?"`
+	_      struct{}       `regexp:"$"`
+	End    Pos
 }
 
 func assertRegion(t *testing.T, s string, begin int, end int, r *Region) {

--- a/restructure_test.go
+++ b/restructure_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func assertRegion(t *testing.T, s string, begin int, end int, r *Region) {
+func assertRegion(t *testing.T, s string, begin int, end int, r *Submatch) {
 	assert.NotNil(t, r)
 	assert.Equal(t, s, string(r.Bytes))
 	assert.EqualValues(t, begin, r.Begin)
@@ -171,13 +171,13 @@ func TestRemoveSubcaptures(t *testing.T) {
 }
 
 type DotNameRegion struct {
-	Dot  *Region `regexp:"\\."`
-	Name *Region `regexp:"\\w+"`
+	Dot  *Submatch `regexp:"\\."`
+	Name *Submatch `regexp:"\\w+"`
 }
 
 type DotExprRegion struct {
 	_    struct{}       `regexp:"^"`
-	Head Region         `regexp:"\\w+"`
+	Head Submatch       `regexp:"\\w+"`
 	Tail *DotNameRegion `regexp:"?"`
 	_    struct{}       `regexp:"$"`
 }


### PR DESCRIPTION
This pr makes it possible to find out what position in the input string corresponded to certain sub-positions within the regex. There are two facilities for doing this:

using restructure.Region:

```go
type DotNameRegion struct {
		 Dot  *Region `regexp:"\\."`
		 Name *Region `regexp:"\\w+"`
}

type DotExprRegion struct {
		 _    struct{}       `regexp:"^"`
		 Head Region         `regexp:"\\w+"`
		 Tail *DotNameRegion `regexp:"?"`
		 _    struct{}       `regexp:"$"`
}

func assertRegion(t *testing.T, s string, begin int, end int, r *Region) {
	assert.NotNil(t, r)
	assert.Equal(t, s, string(r.Bytes))
	assert.EqualValues(t, begin, r.Begin)
	assert.EqualValues(t, end, r.End)
}

func TestMatchNameDotNameRegion(t *testing.T) {
		 pattern, err := Compile(DotExprRegion{}, Options{})
		 require.NoError(t, err)

		 var v DotExprRegion
		 assert.True(t, pattern.Find(&v, "foo.bar"))
		 assertRegion(t, "foo", 0, 3, &v.Head)
		 assert.NotNil(t, v.Tail)
		 assertRegion(t, ".", 3, 4, v.Tail.Dot)
		 assertRegion(t, "bar", 4, 7, v.Tail.Name)
}
```

using restructure.Pos:

```go
type DotNamePos struct {
		 Begin  Pos
		 Dot    string `regexp:"\\."`
		 Middle Pos
		 Name   string `regexp:"\\w+"`
		 End    Pos
}

type DotExprPos struct {
		 Begin  Pos
		 _      struct{} `regexp:"^"`
		 Head   string   `regexp:"\\w+"`
		 Middle Pos
		 Tail   *DotNamePos `regexp:"?"`
		 _      struct{}    `regexp:"$"`
		 End    Pos
}

func TestMatchNameDotNamePos(t *testing.T) {
		 pattern, err := Compile(DotExprPos{}, Options{})
		 require.NoError(t, err)

		 var v DotExprPos
		 assert.True(t, pattern.Find(&v, "foo.bar"))
		 assert.EqualValues(t, 0, v.Begin)
		 assert.EqualValues(t, 3, v.Middle)
		 assert.EqualValues(t, 3, v.Tail.Begin)
		 assert.EqualValues(t, 4, v.Tail.Middle)
		 assert.EqualValues(t, 7, v.Tail.End)
		 assert.EqualValues(t, 7, v.End)
}
```