### PR TITLE
Switch from travis to Github actions for CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,37 @@
+name: Go
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build_and_test:
+    name: Build and test
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        go: ['1.13', '1.14', '1.15', '1.16']
+
+    steps:
+    - id: go
+      name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ matrix.go }}
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Build
+      run: go build -v .
+    
+    - name: Test
+      run: go test -v -coverprofile=profile.cov .
+
+    - name: Send coverage
+      run: bash <(curl -s https://codecov.io/bash) -f profile.cov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: go
-go:
-  - tip

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
-[![GoDoc](https://godoc.org/github.com/alexflint/go-restructure?status.svg)](https://godoc.org/github.com/alexflint/go-restructure)
-[![Build Status](https://travis-ci.org/alexflint/go-restructure.svg?branch=master)](https://travis-ci.org/alexflint/go-restructure)
+<h4 align="center">Struct-based argument parsing for Go</h4>
+<p align="center">
+  <a href="https://pkg.go.dev/github.com/alexflint/go-restructure"><img src="https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square" alt="Documentation"></a>
+  <a href="https://github.com/alexflint/go-restructure/actions"><img src="https://github.com/alexflint/go-restructure/workflows/Go/badge.svg" alt="Build Status"></a>
+  <a href="https://codecov.io/gh/alexflint/go-restructure"><img src="https://codecov.io/gh/alexflint/go-restructure/branch/master/graph/badge.svg" alt="Coverage Status"></a>
+  <a href="https://goreportcard.com/report/github.com/alexflint/go-restructure"><img src="https://goreportcard.com/badge/github.com/alexflint/go-restructure" alt="Go Report Card"></a>
+</p>
+<br>
 
 ## Match regular expressions into struct fields
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/alexflint/go-restruture
+
+go 1.15
+
+require (
+	github.com/alexflint/go-restructure v0.0.0-20160131054339-a509d071de28
+	github.com/stretchr/testify v1.7.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/alexflint/go-restructure v0.0.0-20160131054339-a509d071de28 h1:p32gFVhF4WnI/qpSpZ0//GGb6BAAFLVnkd4Vowg7im8=
+github.com/alexflint/go-restructure v0.0.0-20160131054339-a509d071de28/go.mod h1:8Mq15S+jJn5TWrSU0Ua7L8rFWmY06lu0UCbhJrrcGBY=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This PR migrate away from Travis and use Github actions instead. It also introduces go.mod and go.sum files.