### PR TITLE
Allow setting struct fields as int

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,19 @@ func main() {
 }
 ```
 
+### Ints
+
+It is also possible to set struct fields as `int` to get the string automatically converted.
+
+```go
+// Matches "12 wombats", "1 wombat" and store the number as int
+type Wisdom struct {
+	Number   int       `^\d+`
+	_   	 string    `\s+`
+	Animal   string    `\w+`
+}
+```
+
 ### Optional fields
 
 When nesting one struct within another, you can make the nested struct optional by marking it with `?`. The following example parses floating point numbers with optional sign and exponent:

--- a/builder.go
+++ b/builder.go
@@ -16,6 +16,7 @@ const (
 	PosRole
 	SubstructRole
 	StringScalarRole
+	IntScalarRole
 	ByteSliceScalarRole
 	SubmatchScalarRole
 )
@@ -106,6 +107,8 @@ func (b *builder) terminal(f reflect.StructField, fullName string) (*Field, *syn
 		role = EmptyRole
 	case stringType:
 		role = StringScalarRole
+	case intType:
+		role = IntScalarRole
 	case byteSliceType:
 		role = ByteSliceScalarRole
 	case submatchType:

--- a/restructure_test.go
+++ b/restructure_test.go
@@ -308,3 +308,19 @@ func TestFindAllWords_Regions(t *testing.T) {
 	assertRegion(t, "is", 4, 6, words[1].S)
 	assertRegion(t, "spam", 7, 11, words[2].S)
 }
+
+type ExprWithInt struct {
+	Number int    `regexp:"^\\d+"`
+	_      string `regexp:"\\s+"`
+	Animal string `regexp:"\\w+$"`
+}
+
+func TestMatchWithInt(t *testing.T) {
+	pattern, err := Compile(ExprWithInt{}, Options{})
+	require.NoError(t, err)
+
+	var v ExprWithInt
+	assert.True(t, pattern.Find(&v, "4 wombats"))
+	assert.Equal(t, 4, v.Number)
+	assert.Equal(t, "wombats", v.Animal)
+}


### PR DESCRIPTION
Closes #32 

Add ability to set some fields as `int` and get them parsed accordingly.